### PR TITLE
added nb_conda_kernels dependency for making kernel available in jupyter

### DIFF
--- a/Untitled.ipynb
+++ b/Untitled.ipynb
@@ -1,0 +1,6 @@
+{
+ "cells": [],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/kval_template_env.yml
+++ b/kval_template_env.yml
@@ -4,14 +4,15 @@ channels:
   - defaults
 dependencies:
   - python=3.11
+  - jupyter
+  - nb-clean=3.2.0
+  - ipykernel
+  - nb_conda_kernels
   - glob2
   - numpy
   - scipy
   - xarray
   - matplotlib
-  - jupyter
-  - nb-clean=3.2.0
-  - ipykernel
   - cf-units
   - pip
 


### PR DESCRIPTION
Without that dependency, the kernel would not show up in jupyter.